### PR TITLE
node will throw if the request fails and your not listening for 'error', 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,6 +61,9 @@ Client.prototype.call = function(method, params, callback) {
       result.on('data', function (chunk) {
         xmlrpcParser.parseMethodResponse(chunk, callback)
       })
+      result.on('error', function(err){
+        callback(err, null);
+      });
     })
 
     request.write(xml, 'utf8')


### PR DESCRIPTION
node will throw if the request fails and your not listening for 'error', this happens in cases where the url is invalid. This patch fixed.

Consider changing the api method 'call' to 'send'. Initially I assumed it was function.prototype.call being used.
