### PR TITLE
Custom Headers Support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -62,8 +62,12 @@ Client.prototype.methodCall = function(method, params, callback) {
     var request = httpRequester.request(that.options, function(result) {
       // Parses the method response and returns the value
       result.setEncoding('utf8')
+      
+      //must keep track of existing response parser to properly handle multiple
+      //data events. if null is passed in, it will create a new parser.
+      var existingParser = null
       result.on('data', function(chunk) {
-        xmlrpcParser.parseMethodResponse(chunk, callback)
+        existingParser = xmlrpcParser.parseMethodResponse(existingParser, chunk, callback)
       })
       result.on('error', function(error) {
         callback(error, null)

--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -41,24 +41,26 @@ xmlrpcParser.parseMethodCall = function(xml, callback) {
  *     null
  *   - {Object} value - value returned in the method response
  */
-xmlrpcParser.parseMethodResponse = function(xml, callback) {
-
-  var saxParser = new xmlParser.SaxParser(function(parser) {
-
-    deserializeParams(parser, function (error, params, parser) {
-      // There should be only one param returned from a methodResponse
-      var value = null
-      if (params !== undefined
-        && params !== null
-        && params.constructor.name == 'Array'
-        && params.length > 0) {
-        value = params[0]
-      }
-      callback(error, value)
+ 
+xmlrpcParser.parseMethodResponse = function(existingParser, xml, callback) {
+  if (existingParser == null) { 
+	  existingParser = new xmlParser.SaxParser(function(parser) {
+        deserializeParams(parser, function (error, params, parser) {
+        // There should be only one param returned from a methodResponse
+        var value = null
+        if (params !== undefined
+          && params !== null
+          && params.constructor.name == 'Array'
+          && params.length > 0) {
+          value = params[0]
+        }
+        callback(error, value)
+      })
     })
-  })
+  }
 
-  saxParser.parseString(xml)
+  existingParser.parseString(xml)
+  return existingParser
 }
 
 function resetListeners(parser, startElementListener) {


### PR DESCRIPTION
Downloaded your library and tried connecting to a server protected by HTTP Basic auth, and noticed it wouldn't do so. I looked in the code and noticed that you're always overwriting whatever headers go in with your pre-defined headers. This small change keeps your pre-defined headers but also allows for custom headers to be sent (such as HTTP authentication).
