### PR TITLE
Fix <struct> parser

### DIFF
--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -230,6 +230,7 @@ function deserializeArrayParam(parser, callback) {
 
 function deserializeStructParam(parser, callback) {
   var struct = {}
+    , active = false
     , name = null
 
   parser.onStartElementNS(handleStartElement)
@@ -238,8 +239,14 @@ function deserializeStructParam(parser, callback) {
     // Parse each member in the struct XML (denoted by element 'member') and
     // adds to the object
     if (element === 'name') {
+      active = true
       parser.onCharacters(function(chars) {
-        name = chars
+        if (active) {
+          name = chars
+        }
+      })
+      parser.onEndElementNS(function(element, prefix, url) {
+        active = false
       })
     }
     if (element === 'value') {


### PR DESCRIPTION
Hey there Brandon,

Good job on this xmlrpc module. It's been working very nicely so far!

Attached is a fix for the `<struct>` parser. Without this patch, anytime a `<struct>` was being returned, there would be a single property with the name '       \n'. This was a result of 'onCharacters' firing after the "end" event of the <name> tag, and the `name` variable being set to that instead.

Before:

```
{ '             \n': 'Bad login/pass combination.' }
```

After:

```
{ faultCode: 403,
  faultString: 'Bad login/pass combination.' }
```

[bebc8d8](https://github.com/TooTallNate/node-xmlrpc/commit/bebc8d87e5dacf4656997f4c3ba266e46d879d41) is the only really important commit, but the others are nice to have as well. Enjoy and thanks in advance!
