### PR TITLE
Error instances

### DIFF
--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -58,7 +58,15 @@ xmlrpcParser.parseMethodResponse = function(parser, xml, callback) {
           value = params[0]
         }
 
-        callback(error, value)
+        // Ensure that the error that was passed is an Error instance.
+        var err;
+        if (error) {
+          err = new Error(error.faultString);
+          err.code = err.faultCode = error.faultCode;
+          err.faultString = error.faultString;
+        }
+
+        callback(err, value)
       })
     })
   }


### PR DESCRIPTION
If an `error` argument gets passed, it's polite to ensure that it's a real Error instance. That way there's a `err.stack` property to figure out where in the user's code there error occurred.
