### PR TITLE
Fix a bug in the <array> parser when the array contains no values.

### DIFF
--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -213,7 +213,17 @@ function deserializeArrayParam(parser, callback) {
 
   parser.onStartElementNS(handleStartElement)
 
+  function checkForArray (element) {
+    if (element === 'array')
+      callback(null, values)
+  }
+
   function handleStartElement(element, attributes, prefix, uri, namespaces) {
+    // <array>s have a single mandatory <data> tag inside of them. If this is
+    // the <data> tag, then set a listener checking for </array>
+    if (element === 'data') {
+      parser.onEndElementNS(checkForArray)
+    }
     // Parse each element in the array XML (denoted by element 'value') and adds
     // to the array
     if (element === 'value') {
@@ -223,11 +233,7 @@ function deserializeArrayParam(parser, callback) {
         values.push(value)
 
         // If hits the end of this array XML, return the values
-        parser.onEndElementNS(function(element, prefix, uri) {
-          if (element === 'array') {
-            callback(null, values)
-          }
-        })
+        parser.onEndElementNS(checkForArray)
 
       })
     }


### PR DESCRIPTION
Sorry I haven't been updating the tests on these! But basically, if a response contained:

```
<array><data></data></array>
```

Then it would trip up bad. Looking forward to an updated npm release!
