### PR TITLE
The 'stream' and 'endOfDocument' variables should be per-parser, not global

### DIFF
--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -16,6 +16,8 @@ var xmlrpcParser = exports
 xmlrpcParser.parseMethodCall = function(xml, callback) {
 
   var saxParser = new xmlParser.SaxParser(function(parser) {
+    parser._endOfDocument = false
+    parser._stream = ''
 
     // Parses the method name
     deserializeMethod(parser, function(error, method, parser) {
@@ -28,8 +30,6 @@ xmlrpcParser.parseMethodCall = function(xml, callback) {
       })
     })
   })
-  saxParser._endOfDocument = false
-  saxParser._stream = ''
 
   saxParser.parseString(xml)
 }
@@ -47,6 +47,8 @@ xmlrpcParser.parseMethodCall = function(xml, callback) {
 xmlrpcParser.parseMethodResponse = function(parser, xml, callback) {
   if (parser === null) {
     parser = new xmlParser.SaxParser(function(parser) {
+      parser._endOfDocument = false
+      parser._stream = ''
       deserializeParams(parser, function (error, params, parser) {
         // There should be only one param returned from a methodResponse
         var value = null
@@ -69,8 +71,6 @@ xmlrpcParser.parseMethodResponse = function(parser, xml, callback) {
       })
     })
   }
-  parser._endOfDocument = false
-  parser._stream = ''
 
   parser.parseString(xml)
   return parser


### PR DESCRIPTION
I was experiencing a problem where calling an XMLRPC method the first time worked fine, but subsequent requests were failing in weird ways. The callback I gave was being invoked like 3-4 times, all times except for the last has empty arguments passed in.

Upon looking into the source I realized that you were keeping some parsing state globally, instead of "per-parser". So this little patch fixes that.

Thanks in advance!
