### PR TITLE
i8 datatype support

### DIFF
--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -1,6 +1,5 @@
 var xmlParser     = require('node-xml')
   , dateFormatter = require('./date-formatter.js')
-
 var xmlrpcParser = exports
 
 /**
@@ -151,7 +150,7 @@ function deserializeParam(parser, callback) {
 
   parser.onStartElementNS(function(element, attributes, prefix, uri, namespaces) {
     // Checks if element is an XML-RPC data type
-    var flatParams = ['boolean', 'dateTime.iso8601', 'double', 'int', 'i4', 'string', 'nil']
+    var flatParams = ['boolean', 'dateTime.iso8601', 'double', 'int', 'i4', 'i8', 'string', 'nil']
     var isFlatParam = ~flatParams.indexOf(element);
 
     // A non-nested parameter. These simple values can be returned immediately.
@@ -183,6 +182,7 @@ function deserializeParam(parser, callback) {
             param = dateFormatter.decodeIso8601(message)
             break
           case 'double':
+          case 'i8':
             param = parseFloat(message)
             break
           case 'i4':

--- a/test/xmlrpc-parser-test.js
+++ b/test/xmlrpc-parser-test.js
@@ -173,6 +173,19 @@ vows.describe('XML-RPC Parser').addBatch({
         assert.strictEqual(value, 6)
       }
     }
+  , 'with a positive I8 param' : {
+      topic: function() {
+        var xml = '<methodResponse><params>'
+          + '<param><value><i8>6</i8></value></param>'
+          + '</params></methodResponse>'
+        xmlrpcParser.parseMethodResponse(null, xml, this.callback)
+      }
+    , 'contains the positive integer' : function (error, value) {
+      assert.isNull(error)
+      assert.isNumber(value)
+      assert.strictEqual(value, 6)
+    }
+  }
   , 'with a negative Int param' : {
       topic: function() {
         var xml = '<methodResponse><params>'
@@ -199,6 +212,19 @@ vows.describe('XML-RPC Parser').addBatch({
         assert.strictEqual(value, -26)
       }
     }
+  , 'with a negative I8 param' : {
+      topic: function() {
+        var xml = '<methodResponse><params>'
+          + '<param><value><i8>-26</i8></value></param>'
+          + '</params></methodResponse>'
+        xmlrpcParser.parseMethodResponse(null, xml, this.callback)
+      }
+    , 'contains the negative integer' : function (error, value) {
+        assert.isNull(error)
+        assert.isNumber(value)
+        assert.strictEqual(value, -26)
+      }
+    }
   , 'with a Int param of 0' : {
       topic: function() {
         var xml = '<methodResponse><params>'
@@ -216,6 +242,19 @@ vows.describe('XML-RPC Parser').addBatch({
       topic: function() {
         var xml = '<methodResponse><params>'
           + '<param><value><i4>0</i4></value></param>'
+          + '</params></methodResponse>'
+        xmlrpcParser.parseMethodResponse(null, xml, this.callback)
+      }
+    , 'contains the value 0' : function (error, value) {
+        assert.isNull(error)
+        assert.isNumber(value)
+        assert.deepEqual(value, 0)
+      }
+    }
+  , 'with a I8 param of 0' : {
+      topic: function() {
+        var xml = '<methodResponse><params>'
+          + '<param><value><i8>0</i8></value></param>'
           + '</params></methodResponse>'
         xmlrpcParser.parseMethodResponse(null, xml, this.callback)
       }


### PR DESCRIPTION
added i8 datatype support (64-bit integer) using floats due to V8 limitation. for more information read #21

Added three tests which mirror the existing three tests for `i4` datatypes in `xmlrpc-parser-test.js` that test for positive, negative, and zero valued `i4` values. All tests still pass.
