### PR TITLE
adding base64 datatype support using Buffer objects

### DIFF
--- a/lib/xmlrpc-builder.js
+++ b/lib/xmlrpc-builder.js
@@ -76,8 +76,10 @@ function serializeParam(param, paramXml) {
   // Adds boiler plate for the parameter
   var paramXml = paramXml.ele('value')
 
-  switch (typeof(param)) {
+  // check if the param is a Buffer object
+  var paramType = Buffer.isBuffer(param) ? 'buffer' : typeof(param)
 
+  switch (paramType) {
     case 'boolean':
       var logicalValue = param ? 1 : 0
       paramXml.ele('boolean')
@@ -100,6 +102,11 @@ function serializeParam(param, paramXml) {
       }
       break
 
+    case 'buffer':
+      paramXml.ele('base64')
+        .txt(param.toString('base64'))
+      break
+    
     case 'number':
       // Since no is_int or is_float in JavaScript, determines based on if a
       // remainder

--- a/lib/xmlrpc-parser.js
+++ b/lib/xmlrpc-parser.js
@@ -150,7 +150,7 @@ function deserializeParam(parser, callback) {
 
   parser.onStartElementNS(function(element, attributes, prefix, uri, namespaces) {
     // Checks if element is an XML-RPC data type
-    var flatParams = ['boolean', 'dateTime.iso8601', 'double', 'int', 'i4', 'i8', 'string', 'nil']
+    var flatParams = ['boolean', 'dateTime.iso8601', 'double', 'int', 'i4', 'i8', 'string', 'nil', 'base64']
     var isFlatParam = ~flatParams.indexOf(element);
 
     // A non-nested parameter. These simple values can be returned immediately.
@@ -191,6 +191,9 @@ function deserializeParam(parser, callback) {
             break
           case 'string':
             param = message
+            break
+          case 'base64':
+            param = new Buffer(message, 'base64')
             break
         }
 

--- a/test/xmlrpc-builder-test.js
+++ b/test/xmlrpc-builder-test.js
@@ -46,6 +46,16 @@ vows.describe('XML-RPC Builder').addBatch({
         assert.equal(xml, '<?xml version="1.0"?><methodCall><methodName>testMethod</methodName><params><param><value><dateTime.iso8601>20120607T11:35:10</dateTime.iso8601></value></param></params></methodCall>')
       }
     }
+    // Test Base64
+  , 'with a Base64 param' : {
+      topic: function () {
+        xmlrpcBuilder.buildMethodCall('testMethod', [new Buffer('dGVzdGluZw==', 'base64')], this.callback)
+      }
+    , 'contains the base64 string' : function (error, xml) {
+        assert.isNull(error)
+        assert.equal(xml, '<?xml version="1.0"?><methodCall><methodName>testMethod</methodName><params><param><value><base64>dGVzdGluZw==</base64></value></param></params></methodCall>')
+      }
+    }
     // Test Double
   , 'with a positive Double param' : {
       topic: function () {
@@ -205,6 +215,16 @@ vows.describe('XML-RPC Builder').addBatch({
         assert.equal(xml, '<?xml version="1.0"?><methodResponse><params><param><value><dateTime.iso8601>20120807T11:35:10</dateTime.iso8601></value></param></params></methodResponse>')
       }
     }
+    // Test Base64
+  , 'with a Base64 param' : {
+      topic: function () {
+        xmlrpcBuilder.buildMethodResponse(new Buffer('dGVzdGluZw==', 'base64'), this.callback)
+      }
+    , 'contains the base64 string' : function (error, xml) {
+        assert.isNull(error)
+        assert.equal(xml, '<?xml version="1.0"?><methodResponse><params><param><value><base64>dGVzdGluZw==</base64></value></param></params></methodResponse>')
+    }
+  }
     // Test Double
   , 'with a positive Double param' : {
       topic: function () {

--- a/test/xmlrpc-parser-test.js
+++ b/test/xmlrpc-parser-test.js
@@ -101,6 +101,20 @@ vows.describe('XML-RPC Parser').addBatch({
         assert.deepEqual(value, new Date(2012, 05, 08, 11, 35, 10))
       }
     }
+    // Test Base64
+  , 'with a Base64 param' : {
+      topic: function() {
+        var xml = '<methodResponse><params>'
+          + '<param><value><base64>dGVzdGluZw==</base64></value></param>'
+          + '</params></methodResponse>'
+        xmlrpcParser.parseMethodResponse(null, xml, this.callback)
+      }
+    , 'contains the base64 encoded string' : function (error, value) {
+        assert.isNull(error)
+        assert.isObject(value)
+        assert.deepEqual(value, new Buffer('dGVzdGluZw==', 'base64'))
+      }
+    }
     // Test Double
   , 'with a positive Double param' : {
       topic: function() {
@@ -481,6 +495,22 @@ vows.describe('XML-RPC Parser').addBatch({
         assert.deepEqual(params, [new Date(2000, 05, 08, 09, 35, 10)])
       }
     }
+    // Test Base64
+  , 'with a Base64 param' : {
+      topic: function() {
+        var xml = '<methodCall><methodName>testBase64Method</methodName><params>'
+          + '<param><value><base64>dGVzdGluZw==</base64></value></param>'
+          + '</params></methodCall>'
+        xmlrpcParser.parseMethodCall(xml, this.callback)
+      }
+    , 'contains the method name and the base64 Buffer object' : function (error, method, params) {
+        assert.isNull(error)
+        assert.isString(method)
+        assert.strictEqual(method, 'testBase64Method')
+        assert.isArray(params)
+        assert.deepEqual(params, [new Buffer('dGVzdGluZw==', 'base64')])
+    }
+  }
     // Test Double
   , 'with a Double param' : {
       topic: function() {


### PR DESCRIPTION
Refer to #7 . Two tests were added to the builder and the parser mirroring the `DateTime` tests. All tests pass.
