### PR TITLE
Fixed to wait for all chunks from a request before parsing a method call

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -48,9 +48,14 @@ function Server(options, isSecure) {
   httpServer.on('request', function(request, response) {
     request.setEncoding('utf8')
 
-    request.on('data', function (chunk) {
+    var data = ''
+    request.on('data', function(chunk) {
+      data += chunk
+    })
+
+    request.on('end', function () {
       // Parse the method call for a method name and params
-      xmlrpcParser.parseMethodCall(chunk, function(error, methodName, params) {
+      xmlrpcParser.parseMethodCall(data, function(error, methodName, params) {
 
         // Emit the method name and params from the method call
         that.emit(methodName, null, params, function(error, value) {


### PR DESCRIPTION
https://github.com/baalexander/node-xmlrpc/issues/39

I had an issue, where server parsed a valid method call in two (incomplete) parts into two broken calls. This fixed my issue by concatenating all data chunks from request before parsing the method call.
