### PR TITLE
Add listening/close events, and a close() function

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -20,12 +20,12 @@ var http             = require('http')
  *                                  otherwise false.
  * @return {Server}
  */
-function Server(options, isSecure) {
+function Server(options, isSecure, onListening) {
 
   if (false === (this instanceof Server)) {
     return new Server(options, isSecure)
   }
-
+  onListening = onListening || function() {}
   var that = this
 
   // If a string URI is passed in, converts to URI fields
@@ -63,9 +63,7 @@ function Server(options, isSecure) {
                             : http.createServer(handleMethodCall)
 
   process.nextTick(function() {
-    this.httpServer.listen(options.port, options.host, function() {
-      this.emit('listening')
-    }.bind(this))
+    this.httpServer.listen(options.port, options.host, onListening)
   }.bind(this))
   this.close = function(callback) {
     this.httpServer.once('close', callback)

--- a/lib/xmlrpc.js
+++ b/lib/xmlrpc.js
@@ -38,8 +38,8 @@ xmlrpc.createSecureClient = function(options) {
  * @return {Server}
  * @see Server
  */
-xmlrpc.createServer = function(options) {
-  return new Server(options, false)
+xmlrpc.createServer = function(options, callback) {
+  return new Server(options, false, callback)
 }
 
 /**
@@ -51,7 +51,7 @@ xmlrpc.createServer = function(options) {
  * @return {Server}
  * @see Server
  */
-xmlrpc.createSecureServer = function(options) {
-  return new Server(options, true)
+xmlrpc.createSecureServer = function(options, callback) {
+  return new Server(options, true, callback)
 }
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -103,12 +103,11 @@ vows.describe('Server').addBatch({
   }
 , 'close()': {
   topic: function() {
+    console.log()
     var that = this
-    var server = new Server({ port: 9995, path: '/'}, false)
-    server.on('listening', function() {
+    var server = new Server({ port: 9995, path: '/'}, false, function() {
       server.close(function() {
-        var server2 = new Server({ port: 9995, path: '/'}, false)
-        server2.on('listening', that.callback)
+        var server2 = new Server({ port: 9995, path: '/'}, false, that.callback)
       })
     })
   }


### PR DESCRIPTION
Irritating using xmlrpc in a test suite as there's no easy way to stop the server from listening on a port. This patch forwards the http server's 'listening' and 'close' events, and exposes a close() function on the server.
This would allow your own server tests to not require use of unreliable stuff like `setTimeout(doStuff, 500)` to "ensure" server is listening.

One tricky issue that needs to be resolved though, is the fact that normal rpc calls are named events, and this could create confusion for anyone who happens to want to call functions named 'close' or 'listening'. 

Three possible solutions: 
- Option 1: Namespace/private the event names (e.g. "xmlrpc/close" or "_close") to make them far less likely to create conflicts.
- Option 2: Expose the http server and listen for events directly on it, e.g

``` js
var server = xmlrpc.createServer(options)
server.httpServer.on('listening', onListening)
```
- Option 3: Change api to something like:

``` js
var server = xmlrpc.createServer().listen(options, onListening)
server.close(onClose)
```

Last solution probably the best but also most disruptive, second solution good middle ground but verbose, first solution easiest, but doesn't fully solve the problem. Let me know which option sounds good to you and it will be done.
