### PR TITLE
Wildcard method call

### DIFF
--- a/example/client_server.js
+++ b/example/client_server.js
@@ -134,6 +134,15 @@ server.on('fakeFault', function (error, params, callback) {
   serverContents.calls.push('fakeFault')
   callback({ faultCode: 2, faultString: 'Uh oh.'}, null)
 })
+// Handle wildcard message
+server.on('*', function (error, params, foundCallback, notFoundCallback) {
+  if (error == 'wildcardManagedMethod') {
+	  serverContents.calls.push(error)
+	  foundCallback(null, serverContents.calls)
+	  return
+  }
+  notFoundCallback()
+})
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -215,6 +224,10 @@ setTimeout(function () {
     console.log('Get Call Log Response: ' + value)
   })
 
+  client.methodCall('wildcardManagedMethod', null, function (error, value) {
+    console.log('Get Call Log Response via wildcardManagedMethod: '+value);
+  });
+  
   client.methodCall('notFound', null, function (error, value) {
     console.log('notFound: '+error);
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,23 +38,30 @@ function Server(options, isSecure, onListening) {
   function handleMethodCall(request, response) {
     var deserializer = new Deserializer()
     deserializer.deserializeMethodCall(request, function(error, methodName, params) {
-      if (that._events.hasOwnProperty(methodName)) {
-        that.emit(methodName, null, params, function(error, value) {
-          var xml = null
-          if (error !== null) {
-            xml = Serializer.serializeFault(error)
-          }
-          else {
-            xml = Serializer.serializeMethodResponse(value)
-          }
-          response.writeHead(200, {'Content-Type': 'text/xml'})
-          response.end(xml)
-        })
+
+      function handleMethodFound(error, value) {
+        var xml = null
+        if (error !== null) {
+          xml = Serializer.serializeFault(error)
+        }
+        else {
+          xml = Serializer.serializeMethodResponse(value)
+        }
+        response.writeHead(200, {'Content-Type': 'text/xml'})
+        response.end(xml)
       }
-      else {
-        that.emit('NotFound', methodName, params);
-        response.writeHead(404);
-        response.end();
+
+      function handleMethodNotFound() {
+        response.writeHead(404)
+        response.end()
+      }
+
+      if (that._events.hasOwnProperty(methodName)) {
+        that.emit(methodName, null, params, handleMethodFound)
+      } else if (that._events.hasOwnProperty('*')) {
+        that.emit('*', methodName, params, handleMethodFound, handleMethodNotFound)
+      } else {
+        that.emit('NotFound', methodName, params, handleMethodNotFound)
       }
     })
   }

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -82,6 +82,37 @@ vows.describe('Server').addBatch({
         assert.deepEqual(value, ['Param A', 'Param B'])
       }
     }
+  , 'with wildcard server': {
+      topic: function() {
+        var server = new Server({ port: 9994, path: '/'}, false)
+
+        server.on('*', this.callback);
+        setTimeout(function () {
+          var options = { host: 'localhost', port: 9994, path: '/',
+                            method: 'POST' }
+          var req = http.request(options, function() {})
+          var chunk1 = '<?xml version="1.0" encoding="UTF-8"?>'
+            + '<methodCall>'
+            + '<methodName>testMethod</methodName>'
+            + '<params>'
+            + '<param>'
+            + '<value><string>Param A</string></value>'
+            + '</param>'
+            + '<param>'
+            + '<value><string>Param B</string></value>'
+            + '</param>'
+            + '</params>'
+            + '</methodCall>'
+          req.on('error', function(e) { assert.isNull(e); })
+          req.write(chunk1)
+          req.end()
+        }, 500)
+      }
+    , 'known method' : function (method, params) {
+        assert.equal(method, 'testMethod')
+        assert.deepEqual(params, ['Param A', 'Param B'])
+      }
+    }
   }
 , 'Another call' :{
     'with an unknown method': {
@@ -115,4 +146,5 @@ vows.describe('Server').addBatch({
       assert.ifError(error)
     }
   }
+
 }).export(module)


### PR DESCRIPTION
Hi!
I'm working on some use cases when the availability of a method call is known only once the call has been triggered, so I've introduced the possibility to handle wildcard method calls (only server side) using the '*' character which is not valid for method names according to the XML-RPC standard. Unlike the standard callback, the wildcard handler takes two callbaks, one when the method is manageable, while the other (not found) when not. Sure, the code can describe the new behavior better. I've improved the example and added one test.

Thanks for the work on node-xmlrpc, hope this can help to improve it.

Michele.
