### PR TITLE
Enable CI for node 0.10.x and 0.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "0.6"
   - "0.8"
-
+  - "0.10"
+  - "0.11"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   , "xmlbuilder" : "0.4.2"
   }
 , "devDependencies" : {
-    "vows" : "0.6.x"
+    "vows" : "0.7.x"
   }
 , "scripts" : {
     "test" : "make test"


### PR DESCRIPTION
I enabled node 0.10/0.11 in .travis.yml to extend CI to those versions.

Had to update vows to 0.7.x, as 0.6.3 doesn't work on 0.10.
