### PR TITLE
CustomType class implementation

### DIFF
--- a/lib/customtype.js
+++ b/lib/customtype.js
@@ -1,0 +1,10 @@
+var CustomType = module.exports = function (raw) {
+	this.raw = raw;
+};
+
+CustomType.prototype.serialize = function (xml) {
+	return xml.ele(this.tagName).txt(this.raw);
+};
+
+CustomType.prototype.tagName = 'customType';
+

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -1,5 +1,6 @@
 var xmlBuilder    = require('xmlbuilder')
   , dateFormatter = require('./date_formatter')
+  , CustomType    = require('./customtype')
 
 /**
  * Creates the XML for an XML-RPC method call.
@@ -107,6 +108,10 @@ function serializeValue(value, xml) {
           }
           else if (Buffer.isBuffer(current.value)) {
             appendBuffer(current.value, valueNode)
+            stack.pop()
+          }
+          else if (current.value instanceof CustomType) {
+            current.value.serialize(valueNode)
             stack.pop()
           }
           else {

--- a/lib/xmlrpc.js
+++ b/lib/xmlrpc.js
@@ -1,5 +1,6 @@
 var Client = require('./client')
   , Server = require('./server')
+  , CustomType = require('./customtype');
 
 var xmlrpc = exports
 
@@ -59,3 +60,4 @@ xmlrpc.createSecureServer = function(options, callback) {
   return new Server(options, true, callback)
 }
 
+xmlrpc.CustomType = CustomType;

--- a/test/fixtures/good_food/customtype_call.xml
+++ b/test/fixtures/good_food/customtype_call.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><methodCall><methodName>testMethod</methodName><params><param><value><customType>testCustomType</customType></value></param></params></methodCall>

--- a/test/fixtures/good_food/customtype_extended_call.xml
+++ b/test/fixtures/good_food/customtype_extended_call.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><methodCall><methodName>testMethod</methodName><params><param><value><extendedCustomType>extendedTestCustomType</extendedCustomType></value></param></params></methodCall>

--- a/test/fixtures/good_food/customtype_extended_response.xml
+++ b/test/fixtures/good_food/customtype_extended_response.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><methodResponse><params><param><value><extendedCustomType>extendedTestCustomType</extendedCustomType></value></param></params></methodResponse>

--- a/test/fixtures/good_food/customtype_response.xml
+++ b/test/fixtures/good_food/customtype_response.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><methodResponse><params><param><value><customType>testCustomType</customType></value></param></params></methodResponse>

--- a/test/serializer_test.js
+++ b/test/serializer_test.js
@@ -3,6 +3,8 @@ var vows       = require('vows')
   , fs         = require('fs')
   , assert     = require('assert')
   , Serializer = require('../lib/serializer')
+  , CustomType = require('../lib/customtype')
+  , util = require('util')
 
 vows.describe('Serializer').addBatch({
 
@@ -189,7 +191,28 @@ vows.describe('Serializer').addBatch({
       }
 
     }
-
+  , 'CustomType': {
+        'default' : {
+            topic: function () {
+              var value = new CustomType('testCustomType')
+              return Serializer.serializeMethodCall('testMethod', [value])
+            }
+          , 'contains the customType': assertXml('good_food/customtype_call.xml')
+        }
+      , 'extended' : {
+          topic: function () {
+            var ExtendedCustomType = function (raw) {
+              raw = 'extended' + raw;
+              CustomType.call(this, raw);
+            }
+            util.inherits(ExtendedCustomType, CustomType);
+            ExtendedCustomType.prototype.tagName = 'extendedCustomType';
+            var value = new ExtendedCustomType('TestCustomType')
+            return Serializer.serializeMethodCall('testMethod', [value])
+          }
+        , 'contains the customType': assertXml('good_food/customtype_extended_call.xml')
+      }
+    }
   }
 
 , 'serializeMethodResponse() called with': {
@@ -355,6 +378,28 @@ vows.describe('Serializer').addBatch({
 
     }
 
+  , 'CustomType': {
+      'default' : {
+          topic: function () {
+            var value = new CustomType('testCustomType')
+            return Serializer.serializeMethodResponse(value)
+          }
+        , 'contains the customType': assertXml('good_food/customtype_response.xml')
+      }
+    , 'extended' : {
+        topic: function () {
+          var ExtendedCustomType = function (raw) {
+            raw = 'extended' + raw;
+            CustomType.call(this, raw);
+          }
+          util.inherits(ExtendedCustomType, CustomType);
+          ExtendedCustomType.prototype.tagName = 'extendedCustomType';
+          var value = new ExtendedCustomType('TestCustomType')
+          return Serializer.serializeMethodResponse(value)
+        }
+      , 'contains the customType': assertXml('good_food/customtype_extended_response.xml')
+      }
+    }
   }
 }).export(module)
 


### PR DESCRIPTION
As proposed by @baalexander in #63, this implements a `CustomType` class to be able to manipulate the serializer to generate xml in a certain way.
## usage

``` javascript
var xmlrpc = require('xmlrpc');
var util = require('util');

// create your custom class
var YourType = function (raw) {
  xmlrpc.CustomType.call(this, raw);
};

// inherit everything
util.inherits(YourType, xmlrpc.CustomType);

// set a custom tagName (defaults to 'customType')
YourType.prototype.tagName = 'YourType';

// optionally, override the serializer
YourType.prototype.serialize = function (xml) {
  var value = somefunction(this.raw);
  return xml.ele(this.tagName).txt(value);
}
```

test/serializer_test.js has been updated with method call and response tests for both the plain CustomType class and a derived class as a parameter.

I gave some thought to implementing something like `xmlrpc.createCustomType(tagName, constr, serializer)` but decided that this might be making things more obscure than they have to be, so I left that for now.
