### PR TITLE
fix blocking client test

### DIFF
--- a/test/client_test.js
+++ b/test/client_test.js
@@ -268,10 +268,8 @@ vows.describe('Client').addBatch({
       topic: function () {
         var that = this
         http.createServer(function(request, response) {
-          request.on('end', function () {
-            response.writeHead(404)
-            response.end()
-          })
+          response.writeHead(404)
+          response.end()
         }).listen(9099, 'localhost', function() {
           var client = new Client({ host: 'localhost', port: 9099, path: '/'}, false)
           client.methodCall('unknown', null, function (error) {that.callback(error)})


### PR DESCRIPTION
"A method call with an unknown request" did not trigger the callback, but it looks like not calling `HTTPServer#close()` prevented vows from detecting that.

The reason why this happens in node 0.10/0.11 and not in 0.8 is because of the new streams API that was introduced. In contrast to v0.4-v0.8, the v0.10 stream does not emit 'end' before all data is consumed. Since no data is read, i just got rid of the event listener alltogether and just reply straight on connection for this one. 
