### PR TITLE
Fix date_formatter test

### DIFF
--- a/test/date_formatter.js
+++ b/test/date_formatter.js
@@ -2,11 +2,11 @@ var vows           = require('vows')
   , assert         = require('assert')
   , date_formatter = require('../lib/date_formatter')
 
+var LOCAL_DATE = new Date(2014,0,20,14,25,25);
+
 vows.describe('Date Formatter').addBatch({
   "A local date": {
-    topic: function () {
-      return new Date(2014,0,20,14,25,25)
-    }
+    topic: LOCAL_DATE
   , "when encoded": {
       "without hyphens": encodeCase({hyphens: false}, '^\\d{8}T')
     , "with hyphens": encodeCase({hyphens: true}, '^\\d{4}[-]\\d{2}[-]\\d{2}T')
@@ -53,7 +53,7 @@ vows.describe('Date Formatter').addBatch({
           assert.match(str, new RegExp(reStr))
         }
       , "must match the correct time": function (str) {
-          var offset = new Date().getTimezoneOffset()
+          var offset = LOCAL_DATE.getTimezoneOffset()
           var round = (offset < 0) ? 'ceil' : 'floor'
           var reStr = [
             'T[0]?'


### PR DESCRIPTION
When deciding the UTC offset to contruct the regex that checks
proper UTC formatting, the tested date should be used instead
of the current date.

Fixes issue #85
