### PR TITLE
add info properties to the error object on deserialization error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -109,8 +109,22 @@ Client.prototype.methodCall = function methodCall(method, params, callback) {
     }
     else {
       this.headersProcessors.parseResponse(response.headers)
-      var deserializer = new Deserializer(options.responseEncoding)
-      deserializer.deserializeMethodResponse(response, callback)
+      var deserializer = new Deserializer(options.responseEncoding);
+      var doc = '';
+      response.on('data', function(chunk) { doc += chunk; });
+      deserializer.deserializeMethodResponse(response,
+        function(err, result) {
+          if (err) {
+            if (request && request.connection && request.connection._httpMessage) {
+              err.reqHeaders = request.connection._httpMessage._header;
+            }
+            if (response) { err.respStatusCode = response.statusCode; }
+            if (response) { err.respHeadersJSON = JSON.stringify(response.headers); }
+            if (doc) { err.respBody = doc; }
+          }
+          callback(err, result);
+        }
+      );
     }
   }.bind(this))
 


### PR DESCRIPTION
Fix of sorts for https://github.com/baalexander/node-xmlrpc/issues/61. IMO the error message shouldn't be changed, however the extra diagnostic information attached to the error object can be useful to any users downstream.