### PR TITLE
update to support the latest xmlbuilder

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -15,8 +15,7 @@ var xmlBuilder    = require('xmlbuilder')
 exports.serializeMethodCall = function(method, params) {
   var params = params || []
 
-  var xml = xmlBuilder.create()
-    .begin('methodCall', { version: '1.0' })
+  var xml = xmlBuilder.create('methodCall', { version: '1.0' })
     .ele('methodName')
       .txt(method)
     .up()
@@ -40,8 +39,7 @@ exports.serializeMethodCall = function(method, params) {
  *   - {String} xml           - The method response XML.
  */
 exports.serializeMethodResponse = function(result) {
-  var xml = xmlBuilder.create()
-    .begin('methodResponse', { version: '1.0' })
+  var xml = xmlBuilder.create('methodResponse', { version: '1.0' })
     .ele('params')
       .ele('param')
 
@@ -52,8 +50,7 @@ exports.serializeMethodResponse = function(result) {
 }
 
 exports.serializeFault = function(fault) {
-  var xml = xmlBuilder.create()
-    .begin('methodResponse', { version: '1.0' })
+  var xml = xmlBuilder.create('methodResponse', { version: '1.0' })
     .ele('fault')
 
   serializeValue(fault, xml)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 , "main" : "./lib/xmlrpc.js"
 , "dependencies" : {
     "sax"   : "0.4.x"
-  , "xmlbuilder" : "0.4.2"
+  , "xmlbuilder" : "2.4.x"
   }
 , "devDependencies" : {
     "vows" : "0.7.x"


### PR DESCRIPTION
I'm working on packaging node-xmlrpc for Fedora so I need to get it working with the latest versions of its dependencies.

Looks like xmlbuilder changed API quite a while back. Hopefully this is the only change, there is unfortunately no changelog or release notes for xmlbuilder :disappointed: 
