### PR TITLE
Counterproposal for clientside detailed error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,34 @@ var client = xmlrpc.createClient('YOUR_ENDPOINT');
 client.methodCall('YOUR_METHOD', [new YourType(yourVariable)], yourCallback);
 ```
 
+### To Debug (client-side)
+
+Error callbacks on the client are enriched with request and response
+information and the returned body as long as a http connection was made,
+to aide with request debugging. Example:
+
+```javascript
+var client = xmlrpc.createClient({ host: 'example.com', port: 80 });
+client.methodCall('FAULTY_METHOD', [], function (error, value) {
+  if (error) {
+    console.log('error:', error);
+    console.log('req headers:', error.req && error.req._header);
+    console.log('res code:', error.res && error.res.statusCode);
+    console.log('res body:', error.body);
+  } else {
+    console.log('value:', value);
+  }
+});
+
+// error: [Error: Unknown XML-RPC tag 'TITLE']
+// req headers: POST / HTTP/1.1
+// User-Agent: NodeJS XML-RPC Client
+// ...
+// res code: 200
+// res body: <!doctype html>
+// ...
+```
+
 ### To Test
 
 [![Build

--- a/lib/client.js
+++ b/lib/client.js
@@ -109,8 +109,22 @@ Client.prototype.methodCall = function methodCall(method, params, callback) {
     }
     else {
       this.headersProcessors.parseResponse(response.headers)
-      var deserializer = new Deserializer(options.responseEncoding)
-      deserializer.deserializeMethodResponse(response, callback)
+      var deserializer = new Deserializer(options.responseEncoding);
+      var doc = '';
+      response.on('data', function(chunk) { doc += chunk; });
+      deserializer.deserializeMethodResponse(response,
+        function(err, result) {
+          if (err) {
+            if (request && request.connection && request.connection._httpMessage) {
+              err.reqHeaders = request.connection._httpMessage._header;
+            }
+            if (response) { err.respStatusCode = response.statusCode; }
+            if (response) { err.respHeadersJSON = JSON.stringify(response.headers); }
+            if (doc) { err.respBody = doc; }
+          }
+          callback(err, result);
+        }
+      );
     }
   }.bind(this))
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -104,27 +104,31 @@ Client.prototype.methodCall = function methodCall(method, params, callback) {
   options.headers['Content-Length'] = Buffer.byteLength(xml, 'utf8')
   this.headersProcessors.composeRequest(options.headers)
   var request = transport.request(options, function(response) {
+
+    var body = []
+    response.on('data', function (chunk) { body.push(chunk) })
+
+    function __enrichError (err) {
+      Object.defineProperty(err, 'req', { value: request })
+      Object.defineProperty(err, 'res', { value: response })
+      Object.defineProperty(err, 'body', { value: body.join('') })
+      return err
+    }
+
     if (response.statusCode == 404) {
-      callback(new Error('Not Found'));
+      callback(__enrichError(new Error('Not Found')))
     }
     else {
       this.headersProcessors.parseResponse(response.headers)
-      var deserializer = new Deserializer(options.responseEncoding);
-      var doc = '';
-      response.on('data', function(chunk) { doc += chunk; });
-      deserializer.deserializeMethodResponse(response,
-        function(err, result) {
-          if (err) {
-            if (request && request.connection && request.connection._httpMessage) {
-              err.reqHeaders = request.connection._httpMessage._header;
-            }
-            if (response) { err.respStatusCode = response.statusCode; }
-            if (response) { err.respHeadersJSON = JSON.stringify(response.headers); }
-            if (doc) { err.respBody = doc; }
-          }
-          callback(err, result);
+
+      var deserializer = new Deserializer(options.responseEncoding)
+
+      deserializer.deserializeMethodResponse(response, function(err, result) {
+        if (err) {
+          err = __enrichError(err)
         }
-      );
+        callback(err, result)
+      })
     }
   }.bind(this))
 


### PR DESCRIPTION
This is a rewrite/counterproposal to #91, I included the original commit.

This PR adds the entire response object (there are possible debug cases where you'd want to inspect more than just headers/status) and response body to the error object returned by the client whenever an error occurs during the execution of Client.prototype.methodCall, **after** a response has been received from the RPC server. 

The extra properties are added non-enumerable, so that using (implicit) ```.toString()``` on the error (as with ```console.log```) your implementation does not attempt to stringify massive amounts of data.

@baalexander could you please say something about which approach you prefer? Thanks.