### PR TITLE
add originTimezone functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ as separator (default: ```false```)
 * ```ms``` - enables/disables output of milliseconds (default: ```false```)
 * ```offset``` - enables/disables output of UTC offset in case of local time
 (default: ```false```)
+* ```originTimezone``` - format date based on origin's timezone per [moment-timezone](http://momentjs.com/timezone/) (eg. 'America/Los_Angeles')
+(default: ```false```)
 
 
 Default format: 20140101T11:20:00

--- a/lib/date_formatter.js
+++ b/lib/date_formatter.js
@@ -1,3 +1,4 @@
+var moment = require('moment-timezone');
 /**
  * @class DateFormatter
  * The DateFormatter supports decoding from and encoding to
@@ -20,6 +21,7 @@ DateFormatter.DEFAULT_OPTIONS = {
 , local: true
 , ms: false
 , offset: false
+, originTimezone: false
 }
 
 /**
@@ -87,9 +89,10 @@ DateFormatter.prototype.decodeIso8601 = function(time) {
   date += (dateParts[17] !== undefined) ?
     dateParts[17] +
       ((dateParts[19] && dateParts[20] === undefined) ? '00' : '') :
+      this.opts.originTimezone ? '' :
     DateFormatter.formatCurrentOffset(new Date(date))
 
-  return new Date(date)
+  return this.opts.originTimezone ? moment.tz(date, this.opts.originTimezone).toDate() : new Date(date)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 , "dependencies" : {
     "sax"   : "0.6.x"
   , "xmlbuilder" : "2.4.x"
+  , "moment-timezone" : "0.3.x"
   }
 , "devDependencies" : {
     "vows" : "0.7.x"


### PR DESCRIPTION
this PR enables users to define the origin's timezone for the purpose of accurately creating date objects.