### PR TITLE
Boolean parsing and parameter names

### DIFF
--- a/lib/deserializer.js
+++ b/lib/deserializer.js
@@ -214,14 +214,10 @@ Deserializer.prototype.endNil = function(data) {
 }
 
 Deserializer.prototype.endBoolean = function(data) {
-  if (data === '1') {
-    this.push(true)
-  }
-  else if (data === '0') {
-    this.push(false)
-  }
-  else {
-    throw new Error('Illegal boolean value \'' + data + '\'')
+  switch (data.toLowerCase()) {
+    case "true": case "yes": case "1": this.push(true); break
+    case "false": case "no": case "0": this.push(false); break
+    default: throw new Error('Illegal boolean value \'' + data + '\'')
   }
   this.value = false
 }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -27,9 +27,19 @@ exports.serializeMethodCall = function(method, params, encoding) {
     .up()
     .ele('params')
 
-  params.forEach(function(param) {
-    serializeValue(param, xml.ele('param'))
-  })
+  if (params instanceof Array) {
+    params.forEach(function(param) {
+      serializeValue(param, xml.ele('param'))
+    })
+  } else {
+      for (var name in params) {
+        if (params.hasOwnProperty(name)) {
+          var p = xml.ele('param')
+          p.ele("name", name)
+          serializeValue(params[name], p)
+        }
+      }
+  }
 
   // Includes the <?xml ...> declaration
   return xml.doc().toString()


### PR DESCRIPTION
These two changes allow interacting with XML-RPC servers that do things a bit differently. The first change supports decoding response boolean values as true/false strings where as before it would only support booleans as 1/0. The second change allows you to explicitly use a parameter name in a method call. 

An example would be:
`client.methodCall('GetItemByName', {Name:"Linda",SortAscending:true}, function (error, value) { });`
