### PR TITLE
Support for Node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "xmlrpc"
 , "description" : "A pure JavaScript XML-RPC client and server."
 , "keywords" : [ "xml-rpc", "xmlrpc", "xml", "rpc" ]
-, "version" : "1.3.1dev"
+, "version" : "1.3.2"
 , "preferGlobal" : false
 , "homepage" : "https://github.com/baalexander/node-xmlrpc"
 , "author" : "Brandon Alexander <baalexander@gmail.com> (https://github.com/baalexander)"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "xmlrpc"
 , "description" : "A pure JavaScript XML-RPC client and server."
 , "keywords" : [ "xml-rpc", "xmlrpc", "xml", "rpc" ]
-, "version" : "1.3.0"
+, "version" : "1.3.1dev"
 , "preferGlobal" : false
 , "homepage" : "https://github.com/baalexander/node-xmlrpc"
 , "author" : "Brandon Alexander <baalexander@gmail.com> (https://github.com/baalexander)"
@@ -18,7 +18,7 @@
 , "main" : "./lib/xmlrpc.js"
 , "dependencies" : {
     "sax"   : "0.6.x"
-  , "xmlbuilder" : "2.4.x"
+  , "xmlbuilder" : "2.6.x"
   }
 , "devDependencies" : {
     "vows" : "0.7.x"


### PR DESCRIPTION
Using xmlbuilder 2.4.x throws a warning when using Node 12. The tests seem to pass with xmlbuilder 2.6, which says it is compatible with 12. 