### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,6 @@
     "node" : ">=0.8",
     "npm" : ">=1.0.0"
   }
-, "licenses" : [ {
-      "type" : "MIT"
-    , "url" : "https://github.com/baalexander/node-xmlrpc/raw/master/LICENSE"
-    }
-  ]
+, "license" : "MIT"
 }
 


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/