### PR TITLE
Treat string has CDATA as text

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -171,10 +171,14 @@ function appendBoolean(value, xml) {
   xml.ele('boolean').txt(value ? 1 : 0)
 }
 
+var cdata = /<!\[CDATA\[[\s\S]*?\]\]>/
 var illegalChars = /^(?![^<&]*]]>[^<&]*)[^<&]*$/
 function appendString(value, xml) {
   if (value.length === 0) {
     xml.ele('string')
+  }
+  else if (cdata.test(value)) {
+    xml.ele('string').txt(value)
   }
   else if (!illegalChars.test(value)) {
     xml.ele('string').d(value)

--- a/test/fixtures/good_food/string_has_cdata_call.xml
+++ b/test/fixtures/good_food/string_has_cdata_call.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><methodCall><methodName>testMethod</methodName><params><param><value><string>HEAD&lt;![CDATA[Hello Test]]&gt;<html>FOOT</html></string></value></param></params></methodCall>

--- a/test/serializer_test.js
+++ b/test/serializer_test.js
@@ -122,6 +122,13 @@ vows.describe('Serializer').addBatch({
           }
         , 'contains the CDATA-wrapped string': assertXml('good_food/string_multiline_cdata_call.xml')
         }
+      , 'with a string param that has CDATA' : {
+          topic: function () {
+            var value = 'HEAD<![CDATA[Hello Test]]><html>FOOT</html>'
+            return Serializer.serializeMethodCall('testMethod', [value])
+          }
+        , 'contains the cdata string' : assertXml('good_food/string_has_cdata_call.xml')
+        }
       , 'with an empty string' : {
           topic: function () {
             var value = ''


### PR DESCRIPTION
We got 'ERROR Error: Invalid CDATA text' when value has '<!CDATA[[###]]>'.