### PR TITLE
node.js bug with slow socket release workaround

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -36,6 +36,15 @@ function Server(options, isSecure, onListening) {
   }
 
   function handleMethodCall(request, response) {
+    // node.js bug with slow socket release workaround
+    // @see http://habrahabr.ru/post/264851/
+    var socket = request.socket;
+    response.on('finish', function() {
+    socket.removeAllListeners('timeout');
+      socket.setTimeout(5000, function() {
+        socket.destroy();
+      });
+    });
     var deserializer = new Deserializer()
     deserializer.deserializeMethodCall(request, function(error, methodName, params) {
       if (that._events.hasOwnProperty(methodName)) {


### PR DESCRIPTION
see http://habrahabr.ru/post/264851/

The problem is: available socket limit is reached. This workaround solves the problem in some scale.