### PR TITLE
introduce Client.methodCallWithTransport

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -97,9 +97,24 @@ function Client(options, isSecure) {
  *   - {mixed} value          - The value returned in the method response.
  */
 Client.prototype.methodCall = function methodCall(method, params, callback) {
+  var transport = this.isSecure ? https : http
+  this.methodCallWithTransport(transport, method, params, callback)
+};
+
+/**
+ * Makes an XML-RPC call to the server specified by the constructor's options
+ * via the specified transport.
+ *
+ * @param {Object} transport  - The request transport.
+ * @param {String} method     - The method name.
+ * @param {Array} params      - Params to send in the call.
+ * @param {Function} callback - function(error, value) { ... }
+ *   - {Object|null} error    - Any errors when making the call, otherwise null.
+ *   - {mixed} value          - The value returned in the method response.
+ */
+Client.prototype.methodCallWithTransport = function methodCallWithTransport(transport, method, params, callback) {
   var options   = this.options
   var xml       = Serializer.serializeMethodCall(method, params, options.encoding)
-  var transport = this.isSecure ? https : http
 
   options.headers['Content-Length'] = Buffer.byteLength(xml, 'utf8')
   this.headersProcessors.composeRequest(options.headers)


### PR DESCRIPTION
I had forgotten that I had contributed to this project [many years ago](https://github.com/baalexander/node-xmlrpc/pulls?q=is%3Apr+author%3Ablaenk+is%3Aclosed) :smile: 

I really need to be able to perform requests via SCGI instead of HTTP. I was originally doing this by explicitly requiring `xmlrpc/lib/Client`, Deserializer, and so on to attach my own `scgiMethodCall` to the Client's prototype, but I figured that this might be a cleaner way.

Essentially changes Client.methodCall to take a specific transport
object which is used to perform the request. This enables one to use a
transport other than HTTP or HTTPS, for example, SCGI.

The original Client.methodCall is now implemented in terms of this new
method.