### PR TITLE
Fix node-v6 not providing hasOwnProperty for EventEmitter._events

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -38,7 +38,7 @@ function Server(options, isSecure, onListening) {
   function handleMethodCall(request, response) {
     var deserializer = new Deserializer()
     deserializer.deserializeMethodCall(request, function(error, methodName, params) {
-      if (that._events.hasOwnProperty(methodName)) {
+      if (Object.prototype.hasOwnProperty.call(that._events, methodName)) {
         that.emit(methodName, null, params, function(error, value) {
           var xml = null
           if (error !== null) {


### PR DESCRIPTION
node-v6 does not have EventEmitter._events.hasOwnProperty method.