### PR TITLE
Remove CI for node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.11"
   - "0.12"


### PR DESCRIPTION
Our testbed is incompatible with node 0.8 due to dependencies not supporting this version anymore, so it makes no sense to have a failing CI on every PR. 

Since 0.8 is no longer maintained either, removing it is in my opinion the best option. If someone really needs it, it can be brought back at a later time.
