### PR TITLE
Send content-length header in method responses

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,7 +47,10 @@ function Server(options, isSecure, onListening) {
           else {
             xml = Serializer.serializeMethodResponse(value)
           }
-          response.writeHead(200, {'Content-Type': 'text/xml'})
+          response.writeHead(200, {
+            'Content-Type': 'text/xml',
+            'Content-Length': Buffer.byteLength(xml, 'utf8')
+          })
           response.end(xml)
         })
       }


### PR DESCRIPTION
- unlike method calls (client), method responses (server) did not yet
  send content-length headers. This was causing problem with at least
  one client (ros's turtlesim, in the context of rosnodejs: publishing
  to /turtlt1/cmd_vel had no effect on the turtle). This commit fixes
  that.
