### PR TITLE
Add Content-Length header to responses

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,7 +47,10 @@ function Server(options, isSecure, onListening) {
           else {
             xml = Serializer.serializeMethodResponse(value)
           }
-          response.writeHead(200, {'Content-Type': 'text/xml'})
+          response.writeHead(200, {
+            'Content-Length': Buffer.byteLength(xml),
+            'Content-Type': 'text/xml'
+          })
           response.end(xml)
         })
       }


### PR DESCRIPTION
This makes server responses more efficient by disabling chunked transfer encoding, but more importantly the Content-Length header is required for all requests and responses by the XML-RPC spec (see http://xmlrpc.scripting.com/spec.html).