### PR TITLE
Allow overriding of the HTTP method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,7 @@ var http         = require('http')
  *   - {String} url               - (optional) - may be used instead of host/port pair
  *   - {Boolean} cookies          - (optional) - if true then cookies returned by server will be stored and sent back on the next calls.
  *                                  Also it will be possible to access/manipulate cookies via #setCookie/#getCookie methods
+ *   - {String} method            - (optional) - HTTP method to use for request
  * @param {Boolean} isSecure      - True if using https for making calls,
  *                                  otherwise false.
  * @return {Client}
@@ -68,7 +69,7 @@ function Client(options, isSecure) {
     }
   }
 
-  options.method = 'POST'
+  options.method = options.method || 'POST'
   this.options = options
 
   this.isSecure = isSecure


### PR DESCRIPTION
I'm calling a service that requires HTTP method to be 'GET' instead of 'POST'.

I could see it make sense to allow the [transport options](https://github.com/baalexander/node-xmlrpc/blob/d9c88c4185e16637ed5a22c1b91c80e958e8d69e/lib/client.js#L106) to be be modified on a per request basis with some optional options on `client.methodCall` 